### PR TITLE
Fix projectile visibility with fog of war

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -18,7 +18,6 @@ let mouse = { x: 0, y: 0 };
 
 socket.on('playerConnected', data => initGame(data));
 socket.on('res', data => player.home.resources = data);
-socket.on('probe', data => world.streams.push([player.home, data, data.color]));
 
 // User events:
 
@@ -54,13 +53,10 @@ function drag (event) {
 }
 
 function aim () {
-  const [wx, wy] = gfx.w2c(player.home.x, player.home.y);
-  const dx = mouse.x - wx;
-  const dy = mouse.y - wy;
-  const d = dx * dx + dy * dy;
-  const ax = dx / (d * 0.1) + Math.cos(player.angle);
-  const ay = dy / (d * 0.1) + Math.sin(player.angle);
-  player.setAngle(Math.atan2(ay, ax));
+  const [mx, my] = gfx.c2w(mouse.x, mouse.y);
+  const dx = mx - player.home.x;
+  const dy = my - player.home.y;
+  player.setAngle(Math.atan2(dy, dx));
 }
 
 function mouseWheelEvent (event) {
@@ -81,6 +77,7 @@ function updateHUD () {
 }
 
 function gameLoop () {
+  world.updateProbes();
   gfx.render();
   updateHUD();
   requestAnimationFrame(gameLoop);

--- a/public/graphics.js
+++ b/public/graphics.js
@@ -35,22 +35,6 @@ function circle (x, y, radius, color) {
   ctx.fill();
 }
 
-function drawResourceStreams () {
-  const anim = Date.now();
-  for (const [start, end, color] of world.streams) {
-    const dist = Math.sqrt((end.x - start.x) ** 2 + (end.y - start.y) ** 2);
-    let incr = 800 / dist;
-    for (let i = 0; i < 1 - incr; i += incr) {
-      const a = i + incr * (anim & 255) / 256;
-      circle(end.x - (end.x - start.x) * a, end.y - (end.y - start.y) * a, 8, color);
-    }
-    incr = 200 / dist;
-    for (let i = 0; i < 1 - incr; i += incr) {
-      const a = i + incr * (anim & 255) / 256;
-      circle(end.x - (end.x - start.x) * a, end.y - (end.y - start.y) * a, 6, color);
-    }
-  }
-}
 
 function drawPlanet (p) {
   const color = ['#008000', '#0000ff', '#808080', '#ffc0cb'][p.color];
@@ -112,7 +96,6 @@ function render () {
   ctx.save();
   drawGrid();
   drawAim();
-  drawResourceStreams();
   world.planets.forEach(p => drawPlanet(p));
   drawPlayer(player, world);
   drawProjectiles();

--- a/public/player.js
+++ b/public/player.js
@@ -7,6 +7,8 @@ let aimC = [];
 function initPlayer (_home) {
   home = _home;
   power = 1;
+  // reveal an initial area around the player's base
+  world.calculateFOW([[home.x, home.y]], home.radius * 2);
   setAngle(0);
 }
 
@@ -23,7 +25,7 @@ function setAngle (r) {
 }
 
 function sendProbe () {
-
+  world.launchProbe(home, angle, power);
 }
 
 export { initPlayer, adjustPower, setAngle, angle, home, sendProbe, aimC, power };


### PR DESCRIPTION
## Summary
- remove projectile stream rendering
- add fog-of-war grid utilities in `world.js`
- update probe launch and updates to track fog visibility
- reveal area around player's home at start
- render probes only when visible

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842d11cee44832bac9626b357b39ea9