### PR TITLE
Center camera on world center

### DIFF
--- a/game-map.js
+++ b/game-map.js
@@ -1,6 +1,7 @@
 // =================================================================
 // Generate new world
 // =================================================================
+const WORLD_SIZE = 1;
 
 function getRandomInt (min, max) {
   return Math.floor(Math.random() * (max - min) + min);
@@ -46,8 +47,8 @@ function createWorld () {
   // Random planets
   for (let nr = 1; nr < 100; nr++) {
     planets.push({
-      x: Math.random(),
-      y: Math.random(),
+      x: Math.random() * WORLD_SIZE,
+      y: Math.random() * WORLD_SIZE,
       populated: null,
       nr,
       ...generateResources()
@@ -58,6 +59,7 @@ function createWorld () {
   const world = {
     fieldResolution,
     G_CONSTANT: 0.00000004,
+    size: WORLD_SIZE,
     planets
   };
 
@@ -67,7 +69,7 @@ function createWorld () {
   const buffer = new ArrayBuffer(fieldResolution ** 2 * 4 * 2);
   const fxF32 = new DataView(buffer);
   const fyF32 = new DataView(buffer, buffer.byteLength / 2);
-  const worldStep = 1 / (fieldResolution - 1);
+  const worldStep = WORLD_SIZE / (fieldResolution - 1);
   for (let y = 0; y < fieldResolution; y++) {
     const rowOfs = y * fieldResolution;
     for (let x = 0; x < fieldResolution; x++) {

--- a/public/gfx3d.js
+++ b/public/gfx3d.js
@@ -158,11 +158,12 @@ function init () {
   renderer.setSize(width, height);
   const fov = 75;
   const aspect = width / height;
-  camera = new THREE.PerspectiveCamera(fov, aspect, 0.1, 5);
+  const worldSize = world.worldSize || 1;
+  camera = new THREE.PerspectiveCamera(fov, aspect, 0.1, worldSize * 5);
   // camera = new THREE.OrthographicCamera(0, 1, 1, 0, 0.1, 5);
-  camera.position.z = 1;
-  camera.position.x = 0.5;
-  camera.position.y = 0.5;
+  camera.position.z = Math.max(1, worldSize);
+  camera.position.x = worldSize / 2;
+  camera.position.y = worldSize / 2;
   const directionalLight = new THREE.DirectionalLight(0xffffff, 0.5);
   const ambientLight = new THREE.AmbientLight(0x808080);
   scene.add(ambientLight);

--- a/public/world.js
+++ b/public/world.js
@@ -1,6 +1,7 @@
 let fieldResolution;
 let fieldX, fieldY;
 let planets;
+let worldSize = 1;
 const probes = [];
 let fow;
 let fowView;
@@ -8,7 +9,7 @@ const fowResolution = 32;
 
 function initWorld (_world) {
   let field;
-  ({ field, fieldResolution, planets } = _world);
+  ({ field, fieldResolution, planets, size: worldSize = 1 } = _world);
   fieldX = new DataView(field, 0, field.byteLength / 2);
   fieldY = new DataView(field, field.byteLength / 2, field.byteLength / 2);
   fow = new ArrayBuffer(fowResolution * fowResolution * 1);
@@ -25,7 +26,7 @@ function calculateAim (home, angle, power) {
     aimC.push([ax, ay]);
     ax += vx;
     ay += vy;
-    if (ax < 0 || ax > 1 || ay < 0 || ay > 1) {
+    if (ax < 0 || ax > worldSize || ay < 0 || ay > worldSize) {
       break;
     }
     const [gx, gy] = gravity(ax, ay);
@@ -50,8 +51,8 @@ function gravity (x, y) {
     ];
   }
 
-  const xi = x * (fieldResolution - 1);
-  const yi = y * (fieldResolution - 1);
+  const xi = x / worldSize * (fieldResolution - 1);
+  const yi = y / worldSize * (fieldResolution - 1);
   const [gx00, gy00] = getf(xi, yi);
   const [gx10, gy10] = getf(xi + 1, yi);
   const [gx01, gy01] = getf(xi, yi + 1);
@@ -82,10 +83,10 @@ function calculateFOW (path, radius) {
   // implementation does not fade visibility over time but is sufficient for
   // revealing projectiles to other players when they enter a cell.
   const res = fowResolution;
-  const rad = Math.max(1, Math.ceil(radius * res));
+  const rad = Math.max(1, Math.ceil(radius / worldSize * res));
   for (const [x, y] of path) {
-    const cx = Math.floor(x * res);
-    const cy = Math.floor(y * res);
+    const cx = Math.floor(x / worldSize * res);
+    const cy = Math.floor(y / worldSize * res);
     for (let yi = cy - rad; yi <= cy + rad; yi++) {
       if (yi < 0 || yi >= res) continue;
       for (let xi = cx - rad; xi <= cx + rad; xi++) {
@@ -98,8 +99,8 @@ function calculateFOW (path, radius) {
 
 function isInFOW (x, y) {
   const res = fowResolution;
-  const xi = Math.floor(x * res);
-  const yi = Math.floor(y * res);
+  const xi = Math.floor(x / worldSize * res);
+  const yi = Math.floor(y / worldSize * res);
   if (xi < 0 || yi < 0 || xi >= res || yi >= res) return false;
   return fowView[yi * res + xi] !== 0;
 }
@@ -163,5 +164,6 @@ export {
   probes,
   launchProbe,
   updateProbes,
-  recalcProbes
+  recalcProbes,
+  worldSize
 };


### PR DESCRIPTION
## Summary
- add WORLD_SIZE for future expansion
- scale planet placement and field grid to WORLD_SIZE
- expose `worldSize` to the client and adjust graphics camera setup
- scale fog of war and gravity calculations to handle larger worlds

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint .` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec1d3cf4832bbf78e8554ec4da08