### PR TITLE
Implement probe timing delta

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -14,6 +14,7 @@ const socket = io();
 const canvas = document.getElementById('gameCanvas');
 let mouse = { x: 0, y: 0 };
 let aiming = false;
+let lastFrameTime = 0;
 
 // Socket events:
 
@@ -93,8 +94,11 @@ function updateHUD () {
   gui.showValue('metamaterials', player.home.resources.metamaterials);
 }
 
-function gameLoop () {
-  world.updateProbes();
+function gameLoop (timestamp) {
+  if (!lastFrameTime) lastFrameTime = timestamp;
+  const deltaTime = (timestamp - lastFrameTime) / 1000;
+  lastFrameTime = timestamp;
+  world.updateProbes(deltaTime);
   gfx.render();
   updateHUD();
   requestAnimationFrame(gameLoop);
@@ -119,5 +123,5 @@ function initGame (data) {
   canvas.addEventListener('contextmenu', e => e.preventDefault());
   window.addEventListener('resize', gfx.resize);
   // Start game
-  gameLoop();
+  requestAnimationFrame(gameLoop);
 }


### PR DESCRIPTION
## Summary
- add a constant `STEP_DURATION` and track progress for probes
- advance probes by time delta when updating
- compute `deltaTime` from `requestAnimationFrame` in client
- start the game loop using `requestAnimationFrame`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint .` *(fails to pass lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_68446f3715b8832ba75acb2a8b32afae