### PR TITLE
Add world generation options

### DIFF
--- a/game-map.js
+++ b/game-map.js
@@ -44,11 +44,12 @@ function generateResources () {
   };
 }
 
-function createWorld (size = 1) {
+function createWorld (size = 1, options = {}) {
   const worldSize = size;
   const planets = [];
   // Random planets
-  const planetCount = getRandomInt(80, 150);
+  const planetCount = options.planetCount || getRandomInt(80, 150);
+  const gravityScale = options.gravityScale || 1;
   for (let nr = 1; nr <= planetCount; nr++) {
     planets.push({
       x: Math.random() * worldSize,
@@ -62,7 +63,7 @@ function createWorld (size = 1) {
   const fieldResolution = 256;
   const world = {
     fieldResolution,
-    G_CONSTANT: 0.0000001,
+    G_CONSTANT: 0.0000001 * gravityScale,
     size: worldSize,
     planets
   };

--- a/public/client.js
+++ b/public/client.js
@@ -107,9 +107,9 @@ function initGame (data) {
   player.initPlayer(data.currentPlayer);
   gfx.init();
   gfx.setCamera(player.home.x, player.home.y);
-  gui.setupWorldSize(world.worldSize);
-  gui.onGenerateWorld(size => {
-    socket.emit('generateWorld', { size });
+  gui.setupWorldSize(world.worldSize, world.planets.length, data.world.G_CONSTANT);
+  gui.onGenerateWorld(params => {
+    socket.emit('generateWorld', params);
   });
 
   canvas.addEventListener('mousemove', e => { mouse = { x: e.clientX, y: e.clientY }; });

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,10 @@
       <label for="worldSizeRange">World Size</label>
       <input id="worldSizeRange" type="range" min="0.5" max="5" step="0.1" value="1">
       <input id="worldSizeNumber" type="number" min="0.5" max="5" step="0.1" value="1">
+      <label for="planetCountNumber">Planets</label>
+      <input id="planetCountNumber" type="number" min="1" max="200" step="1" value="100">
+      <label for="gravityScale">Gravity Scale</label>
+      <input id="gravityScale" type="number" min="0.1" max="10" step="0.1" value="1">
       <button id="applyWorldSize">Generate</button>
     </div>
   </div>

--- a/public/user-interface.js
+++ b/public/user-interface.js
@@ -15,13 +15,17 @@ for (const disp of ['power', 'angle', 'titanium', 'antimatter', 'metamaterials']
 
 const rangeElm = document.getElementById('worldSizeRange');
 const numberElm = document.getElementById('worldSizeNumber');
+const planetCountElm = document.getElementById('planetCountNumber');
+const gravityScaleElm = document.getElementById('gravityScale');
 const applyElm = document.getElementById('applyWorldSize');
 let worldSizeChangeCb = null;
 let worldGenerateCb = null;
 
-function setupWorldSize (value) {
+function setupWorldSize (value, planetCount, gravityScale) {
   rangeElm.value = value;
   numberElm.value = value;
+  if (planetCount !== undefined) planetCountElm.value = planetCount;
+  if (gravityScale !== undefined) gravityScaleElm.value = gravityScale;
 }
 
 rangeElm.addEventListener('input', () => { numberElm.value = rangeElm.value; });
@@ -34,7 +38,13 @@ numberElm.addEventListener('change', () => {
 });
 
 applyElm.addEventListener('click', () => {
-  if (worldGenerateCb) worldGenerateCb(parseFloat(rangeElm.value));
+  if (worldGenerateCb) {
+    worldGenerateCb({
+      size: parseFloat(rangeElm.value),
+      planetCount: parseInt(planetCountElm.value),
+      gravityScale: parseFloat(gravityScaleElm.value)
+    });
+  }
 });
 
 function onWorldSizeChange (cb) {

--- a/server.js
+++ b/server.js
@@ -43,7 +43,9 @@ function newPlayer (socket) {
 
   socket.on('generateWorld', data => {
     const size = parseFloat(data.size) || 1;
-    regenerateWorld(size);
+    const planetCount = parseInt(data.planetCount) || 100;
+    const gravityScale = parseFloat(data.gravityScale) || 1;
+    regenerateWorld(size, planetCount, gravityScale);
   });
 }
 
@@ -66,9 +68,9 @@ function pushGameState () {
   });
 }
 
-function regenerateWorld (size) {
+function regenerateWorld (size, planetCount, gravityScale) {
   worldSize = size;
-  world = gameMap.createWorld(worldSize);
+  world = gameMap.createWorld(worldSize, { planetCount, gravityScale });
   for (const id of Object.keys(players)) {
     const socket = io.sockets.sockets.get(id);
     if (socket) {
@@ -83,7 +85,7 @@ function regenerateWorld (size) {
 // =================================================================
 
 let worldSize = 1;
-let world = gameMap.createWorld(worldSize);
+let world = gameMap.createWorld(worldSize, { planetCount: 100, gravityScale: 1 });
 const players = {};
 
 io.on('connection', newPlayer);


### PR DESCRIPTION
## Summary
- expand UI with inputs for planet count and gravity scale
- pass world generation parameters through client to server
- support planet count and gravity scaling in world generation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68446bdc6ba8832b98ab091941f7186b