### PR TITLE
3D planet distribution, probe trails, and impact effects

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -54,7 +54,7 @@ socket.on('probeImpact', data => {
   if (target) {
     target.resources = data.targetResources;
   }
-  gfx.flashPlanet(data.targetPlanetNr);
+  gfx.flashPlanet(data.targetPlanetNr, data.hitX, data.hitY);
   audio.playImpact();
 });
 

--- a/public/world.js
+++ b/public/world.js
@@ -155,6 +155,7 @@ function setWorldSize (size) {
   for (const p of planets) {
     p.x *= factor;
     p.y *= factor;
+    if (p.z !== undefined) p.z *= factor;
     p.radius *= factor;
   }
   recalcField();


### PR DESCRIPTION
- Planets now have Z coordinates for volumetric 3D distribution: stars near z=0, gas giants moderate spread, regular planets full range with cluster Z centers for grouped planets
- Probe trails: glowing orange Line2 trails follow probes through space, showing last 80 path steps, auto-cleaned when probes expire
- Impact effects: expanding shockwave ring + 30-particle burst with orange-yellow colors, 1.2s duration with fade and deceleration
- Planets slowly rotate for visual interest
- Player arrow positioned at home planet's Z height
- flashPlanet now accepts hitX/hitY for precise impact location
- Physics remain 2D (gravity field on XY plane), Z is purely visual

https://claude.ai/code/session_011C4e3AUqpLZR38qSxmtH5y